### PR TITLE
feat: prettier 설정 파일 추가

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,10 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "jsxSingleQuote": false,
+  "trailingComma": "all",
+  "printWidth": 120,
+  "tabWidth": 2,
+  "useTabs": false,
+  "endOfLine": "auto"
+}


### PR DESCRIPTION
[2a98e17](https://github.com/Ah-ae/kanban-board/pull/1/commits/2a98e170f846e636fb98f13c3bdc81c00405bf1d) 커밋 남기면서 보니 prettier 포매터 지정을 안해서 세미콜론 사용, 큰따옴포/작은따옴표 때문에 코드베이스가 달라지고 있어서 prettier 설정 파일 추가합니다. 